### PR TITLE
Set up dependabot for Go dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "gomod"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Configure dependabot to run weekly and open 10 PRs at once, to limit how much clicking the maintainer has to do at once.