### PR TITLE
Correct JSON configuration example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,14 @@ This is an HTTP handler module, so it can be used wherever `http.handlers` modul
 			"window": "",
 			"max_events": 0
 		},
-		"distributed": {
-			"write_interval": "",
-			"read_interval": ""
-		},
 		"storage": {},
 		"jitter": 0.0,
 		"sweep_interval": ""
 	}
+	"distributed": {
+		"write_interval": "",
+		"read_interval": ""
+	},
 }
 ```
 


### PR DESCRIPTION
In the first JSON config example, the `distributed` block should be a sibling to `rate_limits`, as it is in the more complete example at the bottom of the README.