### PR TITLE
Provide `retry-after` header value in distributed rate limiting

### DIFF
--- a/ringbuffer.go
+++ b/ringbuffer.go
@@ -62,6 +62,14 @@ func (r *ringBufferRateLimiter) When() time.Duration {
 	return time.Until(r.ring[r.cursor].Add(r.window))
 }
 
+// OldestEvent returns the time at which the oldest recorded event current in
+// the ring buffer occurred.
+func (r *ringBufferRateLimiter) OldestEvent() time.Time {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.ring[r.cursor]
+}
+
 // allowed returns true if the event is allowed to happen right now.
 // It does not wait. If the event is allowed, a reservation is made.
 // It is NOT safe for concurrent use, so it must be called inside a


### PR DESCRIPTION
This is an attempt to provide a useful `retry-after` header value when distributed rate limiting is enabled. In the non-distributed case, this is done by adding the RL window to the time of the oldest event in the ringbuffer. So the approach here is for the distributed RL state to store not just the count of events in each replica's ring buffer, but the time of the oldest event. When a rate limit is exceeded, we find the oldest timestamp across all the replicas, and use that to compute the wait time.

The oldest event times are synced around along with the event counts and updated and read in the same `syncDistributed{Read|Write}` functions, so this shouldn't be much more expensive than it already was.

This worked in a simple integration test of my application (https://github.com/divviup/janus) which uses this plugin as a rate limiting reverse proxy. If you think this is workable, then I can invest some time into setting up unit tests for it here in the `caddy-ratelimit` repository.