### PR TITLE
Don't return an error from `Handler.ServeHTTP`

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -210,7 +210,9 @@ func (h *Handler) rateLimitExceeded(w http.ResponseWriter, repl *caddy.Replacer,
 	// make some information about this rate limit available
 	repl.Set("http.rate_limit.exceeded.name", zoneName)
 
-	return caddyhttp.Error(http.StatusTooManyRequests, nil)
+	w.WriteHeader(http.StatusTooManyRequests)
+
+	return nil
 }
 
 // Cleanup cleans up the handler.


### PR DESCRIPTION
Caddy can be set up to export Prometheus metrics from HTTP servers, and middleware automatically gets wrapped in a `metricsInstrumentedHandler` which will emit histograms of requests times, labeled by the HTTP status. However, this only happens if a handler's `ServeHTTP` method doesn't return an error ([source][1]). The rate limiter's `ServeHTTP` was doing just that, and so the metrics showed no trace of the 429 responses.

[1]: https://github.com/caddyserver/caddy/blob/7d919af01b31aff6eb1086e87784bf59c52419bb/modules/caddyhttp/metrics.go#L140