### PR TITLE
Fix race when initializing ringBufferRateLimiter

### DIFF
--- a/ratelimit.go
+++ b/ratelimit.go
@@ -46,7 +46,7 @@ type RateLimit struct {
 
 	zoneName string
 
-	limiters *sync.Map
+	limitersMap *rateLimitersMap
 }
 
 func (rl *RateLimit) provision(ctx caddy.Context, name string) error {
@@ -69,22 +69,102 @@ func (rl *RateLimit) provision(ctx caddy.Context, name string) error {
 	}
 
 	// ensure rate limiter state endures across config changes
-	rl.limiters = new(sync.Map)
-	if val, loaded := rateLimits.LoadOrStore(name, rl.limiters); loaded {
-		rl.limiters = val.(*sync.Map)
+	rl.limitersMap = newRateLimiterMap()
+	if val, loaded := rateLimits.LoadOrStore(name, rl.limitersMap); loaded {
+		rl.limitersMap = val.(*rateLimitersMap)
 	}
-
-	// update existing rate limiters with new settings
-	rl.limiters.Range(func(key, value interface{}) bool {
-		limiter := value.(*ringBufferRateLimiter)
-		limiter.SetMaxEvents(rl.MaxEvents)
-		limiter.SetWindow(time.Duration(rl.Window))
-		return true
-	})
+	rl.limitersMap.updateAll(rl.MaxEvents, time.Duration(rl.Window))
 
 	return nil
 }
 
 func (rl *RateLimit) permissiveness() float64 {
 	return float64(rl.MaxEvents) / float64(rl.Window)
+}
+
+type rateLimitersMap struct {
+	limiters   map[string]*ringBufferRateLimiter
+	limitersMu sync.Mutex
+}
+
+func newRateLimiterMap() *rateLimitersMap {
+	var rlm rateLimitersMap
+	rlm.limiters = make(map[string]*ringBufferRateLimiter)
+	return &rlm
+}
+
+// getOrInsert returns an existing rate limiter from the map, or inserts a new
+// one with the desired settings and returns it.
+func (rlm *rateLimitersMap) getOrInsert(key string, maxEvents int, window time.Duration) *ringBufferRateLimiter {
+	rlm.limitersMu.Lock()
+	defer rlm.limitersMu.Unlock()
+
+	rateLimiter, ok := rlm.limiters[key]
+	if !ok {
+		newRateLimiter := newRingBufferRateLimiter(maxEvents, window)
+		rlm.limiters[key] = newRateLimiter
+		return newRateLimiter
+	}
+	return rateLimiter
+}
+
+// updateAll updates existing rate limiters with new settings.
+func (rlm *rateLimitersMap) updateAll(maxEvents int, window time.Duration) {
+	rlm.limitersMu.Lock()
+	defer rlm.limitersMu.Unlock()
+
+	for _, limiter := range rlm.limiters {
+		limiter.SetMaxEvents(maxEvents)
+		limiter.SetWindow(time.Duration(window))
+	}
+}
+
+// sweep cleans up expired rate limit states.
+func (rlm *rateLimitersMap) sweep() {
+	rlm.limitersMu.Lock()
+	defer rlm.limitersMu.Unlock()
+
+	for key, rl := range rlm.limiters {
+		func(rl *ringBufferRateLimiter) {
+			rl.mu.Lock()
+			defer rl.mu.Unlock()
+
+			// no point in keeping a ring buffer of size 0 around
+			if len(rl.ring) == 0 {
+				delete(rlm.limiters, key)
+				return
+			}
+
+			// get newest event in ring (should come right before oldest)
+			cursorNewest := rl.cursor - 1
+			if cursorNewest < 0 {
+				cursorNewest = len(rl.ring) - 1
+			}
+			newest := rl.ring[cursorNewest]
+			window := rl.window
+
+			// if newest event in memory is outside the window,
+			// the entire ring has expired and can be forgotten
+			if newest.Add(window).Before(now()) {
+				delete(rlm.limiters, key)
+			}
+		}(rl)
+	}
+}
+
+// rlStateForZone returns the state of all rate limiters in the map.
+func (rlm *rateLimitersMap) rlStateForZone(timestamp time.Time) map[string]rlStateValue {
+	state := make(map[string]rlStateValue)
+
+	rlm.limitersMu.Lock()
+	defer rlm.limitersMu.Unlock()
+	for key, rl := range rlm.limiters {
+		count, oldestEvent := rl.Count(timestamp)
+		state[key] = rlStateValue{
+			Count:       count,
+			OldestEvent: oldestEvent,
+		}
+	}
+
+	return state
 }

--- a/ringbuffer.go
+++ b/ringbuffer.go
@@ -30,16 +30,12 @@ type ringBufferRateLimiter struct {
 	cursor int         // always points to the oldest timestamp
 }
 
-// initialize sets up the rate limiter if it isn't already, allowing maxEvents
+// newRingBufferRateLimiter sets up a new rate limiter, allowing maxEvents
 // in a sliding window of size window. If maxEvents is 0, no events are
 // allowed. If window is 0, all events are allowed. It panics if maxEvents or
-// window are less than zero. This method is idempotent.
-func (r *ringBufferRateLimiter) initialize(maxEvents int, window time.Duration) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.window != 0 || r.ring != nil {
-		return
-	}
+// window are less than zero.
+func newRingBufferRateLimiter(maxEvents int, window time.Duration) *ringBufferRateLimiter {
+	r := new(ringBufferRateLimiter)
 	if maxEvents < 0 {
 		panic("maxEvents cannot be less than zero")
 	}
@@ -48,6 +44,7 @@ func (r *ringBufferRateLimiter) initialize(maxEvents int, window time.Duration) 
 	}
 	r.window = window
 	r.ring = make([]time.Time, maxEvents) // TODO: we can probably pool these
+	return r
 }
 
 // When returns the duration before the next allowable event; it does not block.

--- a/ringbuffer_test.go
+++ b/ringbuffer_test.go
@@ -23,9 +23,8 @@ func TestCount(t *testing.T) {
 	initTime()
 
 	var zeroTime time.Time
-	var rb ringBufferRateLimiter
 	bufSize := 10
-	rb.initialize(bufSize, time.Duration(bufSize)*time.Second)
+	rb := newRingBufferRateLimiter(bufSize, time.Duration(bufSize)*time.Second)
 	startTime := now()
 
 	count, oldest := rb.Count(now())


### PR DESCRIPTION
This closes https://github.com/mholt/caddy-ratelimit/issues/36.

Fixes a race condition between ringBufferRateLimiter creation and its insertion into a map. Do this by locking the entire map when we get or insert a ringBufferRateLimiter.

I have replaced use of sync.Map with a normal  `map[string]*ringBufferRateLimiter` and a `sync.Mutex`. They are passed around with a `rateLimitersMap` struct. I've factored out logic into methods of `rateLimitersMap`, which enables some careful use of defer `rlm.mu.Unlock()` to avoid leaving a lock held open on `panic()`.

We didn't see a need for a sync.Map. The docs suggest against using it for type safety, and none of the suggested use cases apply. https://pkg.go.dev/sync#Map. Let me know if I'm misunderstanding the use case (very possible!).

I've removed the sync.Pool, for now. Since ringBufferRateLimiter creation and insertion is fully synchronized, I didn't see a need for it.

Note that some of the defensive refactoring is not strictly required--I have a change that preserves the existing data structures, but I think the suggested changeset is an overall improvement in maintainability. https://github.com/divviup/caddy-ratelimit/pull/1/commits/65ad951ea012a5410dff297efa9da6f769e20dc0.

Some discussion of the performance impact and profiles is here https://github.com/divviup/caddy-ratelimit/pull/1. TL;DR, no meaningful impact to CPU, memory, or latency. This implementation could be optimized by replacing the normal mutex with a RWMutex, but it would be a marginal improvement (if any) in exchange for much more complicated locking semantics.

I suggest waiting before merging this, while we let it sit in production for a while longer, to ensure the problem is fully fixed. I'll let it sit for about a week. In the mean time, this is ready for code review.