### PR TITLE
downgrade the value of `go` directive in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/mholt/caddy-ratelimit
 
-go 1.22.0
-
-toolchain go1.22.3
+go 1.21.0
 
 require (
 	github.com/caddyserver/caddy/v2 v2.7.6


### PR DESCRIPTION
For all the reasons listed in caddyserver/zerossl#1, caddyserver/certmagic#289, and caddyserver/caddy#6318