### PR TITLE
Optionally delete stale distributed state

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ This is an HTTP handler module, so it can be used wherever `http.handlers` modul
 	}
 	"distributed": {
 		"write_interval": "",
-		"read_interval": ""
+		"read_interval": "",
+		"purge_age": ""
 	},
 }
 ```
@@ -130,6 +131,7 @@ rate_limit {
 	distributed {
 		read_interval  <duration>
 		write_interval <duration>
+		purge_age <duration>
 	}
 	storage <module...>
 	jitter  <percent>

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -46,6 +46,7 @@ func parseCaddyfile(helper httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, e
 //	    distributed {
 //	        read_interval  <duration>
 //	        write_interval <duration>
+//	        purge_age <duration>
 //	    }
 //	    storage <module...>
 //	    jitter  <percent>
@@ -150,6 +151,19 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 							return d.Errf("invalid write interval '%s': %v", d.Val(), err)
 						}
 						h.Distributed.WriteInterval = caddy.Duration(interval)
+
+					case "purge_age":
+						if !d.NextArg() {
+							return d.ArgErr()
+						}
+						if h.Distributed.PurgeAge != 0 {
+							return d.Errf("purge age already specified: %v", h.Distributed.PurgeAge)
+						}
+						age, err := caddy.ParseDuration(d.Val())
+						if err != nil {
+							return d.Errf("invalid purge age '%s': %v", d.Val(), err)
+						}
+						h.Distributed.PurgeAge = caddy.Duration(age)
 					}
 				}
 

--- a/distributed.go
+++ b/distributed.go
@@ -160,7 +160,7 @@ func (h Handler) syncDistributedRead(ctx context.Context) error {
 		if h.Distributed.PurgeAge != 0 && state.Timestamp.Before(now().Add(-time.Duration(h.Distributed.PurgeAge))) {
 			err = h.storage.Delete(ctx, instanceFile)
 			if err != nil {
-				h.logger.Error("cannot delete rate limiter state file",
+				h.logger.Error("cannot delete stale rate limiter state file",
 					zap.String("key", instanceFile),
 					zap.Error(err))
 			}

--- a/distributed.go
+++ b/distributed.go
@@ -46,6 +46,10 @@ type DistributedRateLimiting struct {
 	// Default: 5s
 	ReadInterval caddy.Duration `json:"read_interval,omitempty"`
 
+	// How long to wait before deleting stale states from other instances.
+	// Default: never
+	PurgeAge caddy.Duration `json:"purge_age,omitempty"`
+
 	instanceID string
 
 	otherStates   []rlState
@@ -150,6 +154,16 @@ func (h Handler) syncDistributedRead(ctx context.Context) error {
 			h.logger.Error("corrupted rate limiter state file",
 				zap.String("key", instanceFile),
 				zap.Error(err))
+			continue
+		}
+
+		if h.Distributed.PurgeAge != 0 && state.Timestamp.Before(now().Add(-time.Duration(h.Distributed.PurgeAge))) {
+			err = h.storage.Delete(ctx, instanceFile)
+			if err != nil {
+				h.logger.Error("cannot delete rate limiter state file",
+					zap.String("key", instanceFile),
+					zap.Error(err))
+			}
 			continue
 		}
 

--- a/distributed_test.go
+++ b/distributed_test.go
@@ -158,7 +158,8 @@ func TestDistributed(t *testing.T) {
 								},
 								"distributed": {
 									"write_interval": "3600s",
-									"read_interval": "3600s"
+									"read_interval": "3600s",
+									"purge_age": "7200s"
 								}
 							},
 							{


### PR DESCRIPTION
This adds a new optional configuration parameter, to allow deleting stale distributed rate limiter state. Closes #50.

I have manually tested this locally, next I plan to add unit testing.