### PR TITLE
Log key when rate limit has been exceeded.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,11 @@ This is an HTTP handler module, so it can be used wherever `http.handlers` modul
 			"window": "",
 			"max_events": 0
 		},
-		"storage": {},
 		"jitter": 0.0,
 		"sweep_interval": ""
-	}
+	},
+	"log_key": false,
+	"storage": {},
 	"distributed": {
 		"write_interval": "",
 		"read_interval": "",
@@ -98,6 +99,8 @@ This is an HTTP handler module, so it can be used wherever `http.handlers` modul
 All fields are optional, but to be useful, you'll need to define at least one zone, and a zone requires `window` and `max_events` to be set. Keys can be static (no placeholders) or dynamic (with placeholders). Matchers can be used to filter requests that apply to a zone. Replace `<name>` with your RL zone's name.
 
 To enable distributed RL, set `distributed` to a non-null object. The default read and write intervals are 5s, but you should tune these for your individual deployments.
+
+To log the key when a rate limit is hit, set `log_key` to `true`.
 
 Storage customizes the storage module that is used. Like normal Caddy convention, all instances with the same storage configuration are considered to be part of a cluster.
 
@@ -133,6 +136,7 @@ rate_limit {
 		write_interval <duration>
 		purge_age <duration>
 	}
+	log_key <bool>
 	storage <module...>
 	jitter  <percent>
 	sweep_interval <duration>

--- a/distributed.go
+++ b/distributed.go
@@ -206,7 +206,7 @@ func (h Handler) distributedRateLimiting(w http.ResponseWriter, r *http.Request,
 
 			// no point in counting more if we're already over
 			if totalCount >= maxAllowed {
-				return h.rateLimitExceeded(w, r, repl, zoneName, oldestEvent.Add(window).Sub(now()))
+				return h.rateLimitExceeded(w, r, repl, zoneName, rlKey, oldestEvent.Add(window).Sub(now()))
 			}
 		}
 	}
@@ -228,7 +228,7 @@ func (h Handler) distributedRateLimiting(w http.ResponseWriter, r *http.Request,
 	limiter.mu.Unlock()
 
 	// otherwise, it appears limit has been exceeded
-	return h.rateLimitExceeded(w, r, repl, zoneName, oldestEvent.Add(window).Sub(now()))
+	return h.rateLimitExceeded(w, r, repl, zoneName, rlKey, oldestEvent.Add(window).Sub(now()))
 }
 
 type rlStateValue struct {

--- a/handler.go
+++ b/handler.go
@@ -203,20 +203,20 @@ func (h *Handler) rateLimitExceeded(w http.ResponseWriter, r *http.Request, repl
 		remoteIP = r.RemoteAddr // assume there was no port, I guess
 	}
 
+	// Create logger with common fields
+	logger := h.logger.With(
+		zap.String("zone", zoneName),
+		zap.Duration("wait", wait),
+		zap.String("remote_ip", remoteIP),
+	)
+
+	// Conditionally add the key field
 	if h.LogKey {
-		h.logger.Info("rate limit exceeded",
-			zap.String("zone", zoneName),
-			zap.String("key", key),
-			zap.Duration("wait", wait),
-			zap.String("remote_ip", remoteIP),
-		)
-	} else {
-		h.logger.Info("rate limit exceeded",
-			zap.String("zone", zoneName),
-			zap.Duration("wait", wait),
-			zap.String("remote_ip", remoteIP),
-		)
+		logger = logger.With(zap.String("key", key))
 	}
+
+	// Log the rate limit exceeded message
+	logger.Info("rate limit exceeded")
 
 	// make some information about this rate limit available
 	repl.Set("http.rate_limit.exceeded.name", zoneName)


### PR DESCRIPTION
# Why?

I'd like to know the key for which the rate limit has been exceeded.

# Test

I tested both for `distributed: {}` and without it.

### Caddy JSON rate limit setup
```
{
  "handler": "rate_limit",
  "rate_limits": {
    "dynamic_example": {
      "key": "{http.request.host}",
      "window": "5m",
      "max_events": 2
    }
  },
  "storage": {
    "module": "redis",
    "address": [
      "localhost:6379"
    ],
    "username": "",
    "password": "",
    "db": 0,
    "timeout": "5",
    "key_prefix": "caddy-rate-limit",
    "encryption_key": "",
    "compression": false,
    "tls_enabled": false,
    "tls_insecure": true
  },
  "distributed": {}
}
```

### Resulting logs (prettified)
```json
{
  "level": "info",
  "ts": "2024-06-28T12:54:58.067Z",
  "logger": "http.handlers.rate_limit",
  "msg": "rate limit exceeded",
  "zone": "dynamic_example",
  "key": "localhost",
  "wait": 297.70859879,
  "remote_ip": "172.17.0.1"
}
```

I'm not an expert in Go so please let me know if this is good enough to merge.

Cheers!