### PR TITLE
feat: concurrency limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This module implements both internal and distributed HTTP rate limiting. Request
 	- Static or dynamic
 	- Can be based on request host, header, remote IP, client IP, etc.
 - Sliding window algorithm
+- Atomic counter implementation for concurrency limiting
 - Scalable ring buffer implementation
 	- Buffer pooling
 	- Goroutines: 1 (to clean up old buffers)
@@ -45,11 +46,13 @@ $ xcaddy build --with github.com/mholt/caddy-ratelimit
 
 ## Overview
 
-The `rate_limit` HTTP handler module lets you define rate limit zones, which have a unique name of your choosing. A rate limit zone is 1:1 with a rate limit (i.e. events per duration).
+The `rate_limit` HTTP handler module lets you define rate limit zones, which have a unique name of your choosing. A rate limit zone is 1:1 with a rate limit (i.e. events per duration) or a concurrency limit (i.e. maximum concurrent requests).
 
-A zone also has a key, which is different from its name. Keys associate 1:1 with rate limiters, implemented as ring buffers; i.e. a new key implies allocating a new ring buffer. Keys can be static (no placeholders; same for every request), in which case only one rate limiter will be allocated for the whole zone. Or, keys can contain placeholders which can be different for every request, in which case a zone may contain numerous rate limiters depending on the result of expanding the key.
+A zone also has a key, which is different from its name. Keys associate 1:1 with rate limiters, implemented as ring buffers (or atomic counters for concurrency limits); i.e. a new key implies allocating a new rate limiter. Keys can be static (no placeholders; same for every request), in which case only one rate limiter will be allocated for the whole zone. Or, keys can contain placeholders which can be different for every request, in which case a zone may contain numerous rate limiters depending on the result of expanding the key.
 
 A zone is synonymous with a rate limit, being a number of events per duration. Both `window` and `max_events` are required configuration for a zone. For example: 100 events every 1 minute. Because this module uses a sliding window algorithm, it works by looking back `<window>` duration and seeing if `<max_events>` events have already happened in that timeframe. If so, an internal HTTP 429 error is generated and returned, invoking error routes which you have defined (if any). Otherwise, a reservation is made and the event is allowed through.
+
+Alternatively, a zone can be a concurrency limit. In this case, `max_concurrent` is required instead. It limits the number of in-flight requests for a given key. When the limit is reached, subsequent requests for that key are rejected until one of the in-flight requests completes. (Note: Distributed rate limiting is currently only supported for windowed rate limits, not for concurrency limits.)
 
 Each zone may optionally filter the requests it applies to by specifying [request matchers](https://caddyserver.com/docs/modules/http#servers/routes/match).
 
@@ -78,7 +81,8 @@ This is an HTTP handler module, so it can be used wherever `http.handlers` modul
 			"match": [],
 			"key": "",
 			"window": "",
-			"max_events": 0
+			"max_events": 0,
+			"max_concurrent": 0
 		}
 	},
 	"jitter": 0.0,
@@ -89,14 +93,14 @@ This is an HTTP handler module, so it can be used wherever `http.handlers` modul
 		"write_interval": "",
 		"read_interval": "",
 		"purge_age": ""
-	},
+	}
 }
 ```
 
 
-All fields are optional, but to be useful, you'll need to define at least one zone, and a zone requires `window` and `max_events` to be set. Keys can be static (no placeholders) or dynamic (with placeholders). Matchers can be used to filter requests that apply to a zone. Replace `<name>` with your RL zone's name.
+All fields are optional, but to be useful, you'll need to define at least one zone. A zone requires either `window` and `max_events` for rate limiting, OR `max_concurrent` for concurrency limiting. Keys can be static (no placeholders) or dynamic (with placeholders). Matchers can be used to filter requests that apply to a zone. Replace `<name>` with your RL zone's name.
 
-To enable distributed RL, set `distributed` to a non-null object. The default read and write intervals are 5s, but you should tune these for your individual deployments.
+To enable distributed RL, set `distributed` to a non-null object. The default read and write intervals are 5s, but you should tune these for your individual deployments. (Note: Distributed rate limiting is currently only supported for windowed rate limits, not for concurrency limits.)
 
 To log the key when a rate limit is hit, set `log_key` to `true`.
 
@@ -146,6 +150,7 @@ rate_limit {
 		key    <string>
 		window <duration>
 		events <max_events>
+		max_concurrent <int>
 	}
 	distributed {
 		read_interval  <duration>
@@ -244,4 +249,17 @@ rate_limit {
 }
 
 respond "I'm behind the rate limiter!"
+```
+
+### Concurrency limiting example
+
+This example limits each client IP to 5 concurrent requests.
+
+```
+rate_limit {
+	zone concurrency_example {
+		key            {remote_host}
+		max_concurrent 5
+	}
+}
 ```

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -43,6 +43,7 @@ func parseCaddyfile(helper httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, e
 //	        key    <string>
 //	        window <duration>
 //	        events <max_events>
+//	        max_concurrent <int>
 //	        match {
 //	        	<matchers>
 //	        }
@@ -109,6 +110,19 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 						}
 						zone.MaxEvents = maxEvents
 
+					case "max_concurrent":
+						if !d.NextArg() {
+							return d.ArgErr()
+						}
+						if zone.MaxConcurrent != 0 {
+							return d.Errf("zone max concurrent already specified: %v", zone.MaxConcurrent)
+						}
+						maxConcurrent, err := strconv.Atoi(d.Val())
+						if err != nil {
+							return d.Errf("invalid max concurrent integer '%s': %v", d.Val(), err)
+						}
+						zone.MaxConcurrent = maxConcurrent
+
 					case "match":
 						matcherSet, err := caddyhttp.ParseCaddyfileNestedMatcherSet(d)
 						if err != nil {
@@ -121,8 +135,12 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 						return d.Errf("unrecognized subdirective '%s'", d.Val())
 					}
 				}
-				if zone.Window == 0 || zone.MaxEvents == 0 {
-					return d.Err("a rate limit zone requires both a window and maximum events")
+
+				if zone.MaxConcurrent > 0 && (zone.Window > 0 || zone.MaxEvents > 0) {
+					return d.Err("a rate limit zone cannot have both max_concurrent and window/events")
+				}
+				if zone.MaxConcurrent == 0 && (zone.Window == 0 || zone.MaxEvents == 0) {
+					return d.Err("a rate limit zone requires either window and events, or max_concurrent")
 				}
 
 				if h.RateLimits == nil {

--- a/caddyfile_test.go
+++ b/caddyfile_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/caddytest"
 )
 
@@ -72,4 +73,55 @@ func TestCaddyfileRateLimits(t *testing.T) {
 	advanceTime(window)
 
 	tester.AssertGetResponse("http://localhost:8080", 200, "")
+}
+
+func TestCaddyfileParseErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		caddyfile string
+		wantErr   bool
+	}{
+		{
+			name: "valid max_concurrent",
+			caddyfile: `rate_limit {
+				zone test {
+					key static
+					max_concurrent 5
+				}
+			}`,
+			wantErr: false,
+		},
+		{
+			name: "mixing max_concurrent and window",
+			caddyfile: `rate_limit {
+				zone test {
+					key static
+					window 10s
+					events 5
+					max_concurrent 5
+				}
+			}`,
+			wantErr: true,
+		},
+		{
+			name: "missing max_concurrent and window",
+			caddyfile: `rate_limit {
+				zone test {
+					key static
+				}
+			}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := caddyfile.NewTestDispenser(tt.caddyfile)
+			h := new(Handler)
+			err := h.UnmarshalCaddyfile(d)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("UnmarshalCaddyfile() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
 }

--- a/concurrency.go
+++ b/concurrency.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Matthew Holt
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// 	http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package caddyrl
+
+import (
+	"sync/atomic"
+)
+
+type concurrencyLimiter struct {
+	current    atomic.Int64
+	limit      atomic.Int64
+	lastAccess atomic.Int64
+}
+
+func (*concurrencyLimiter) isRateLimiter() {}
+
+func newConcurrencyLimiter(limit int64) *concurrencyLimiter {
+	cl := &concurrencyLimiter{}
+	cl.limit.Store(limit)
+	cl.lastAccess.Store(now().UnixNano())
+	return cl
+}
+
+func (cl *concurrencyLimiter) Acquire() bool {
+	for {
+		cur := cl.current.Load()
+		if cur >= cl.limit.Load() {
+			return false
+		}
+		if cl.current.CompareAndSwap(cur, cur+1) {
+			cl.lastAccess.Store(now().UnixNano())
+			return true
+		}
+	}
+}
+
+func (cl *concurrencyLimiter) Release() {
+	cl.current.Add(-1)
+	cl.lastAccess.Store(now().UnixNano())
+}

--- a/concurrency_test.go
+++ b/concurrency_test.go
@@ -1,0 +1,436 @@
+// Copyright 2026 Matthew Holt
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// 	http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package caddyrl
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddytest"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+)
+
+var blockChan = make(chan struct{})
+var enteredChan = make(chan struct{}, 10)
+
+func init() {
+	caddy.RegisterModule(BlockHandler{})
+}
+
+type BlockHandler struct{}
+
+func (BlockHandler) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "http.handlers.test_block",
+		New: func() caddy.Module { return new(BlockHandler) },
+	}
+}
+
+func (h BlockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
+	enteredChan <- struct{}{}
+	<-blockChan
+	w.WriteHeader(200)
+	return nil
+}
+
+func TestConcurrencyLimit(t *testing.T) {
+	// Clear any leftover state
+	for len(enteredChan) > 0 {
+		<-enteredChan
+	}
+
+	maxConcurrent := 2
+	config := fmt.Sprintf(`{
+	"admin": {"listen": "localhost:2999"},
+	"apps": {
+		"http": {
+			"servers": {
+				"demo": {
+					"listen": [":8080"],
+					"routes": [{
+						"handle": [
+							{
+								"handler": "rate_limit",
+								"rate_limits": {
+									"concurrency_zone": {
+										"key": "static",
+										"max_concurrent": %d
+									}
+								}
+							},
+							{
+								"handler": "test_block"
+							}
+						]
+					}]
+				}
+			}
+		}
+	}
+}`, maxConcurrent)
+
+	tester := caddytest.NewTester(t)
+	tester.InitServer(config, "json")
+
+	var wg sync.WaitGroup
+	reqDone := make(chan struct{}, 10)
+	// Start maxConcurrent requests
+	for i := 0; i < maxConcurrent; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() { reqDone <- struct{}{} }()
+			resp, err := http.Get("http://localhost:8080")
+			if err != nil {
+				t.Errorf("request failed: %v", err)
+				return
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != 200 {
+				t.Errorf("expected status 200, got %d", resp.StatusCode)
+			}
+		}()
+	}
+
+	// Wait for requests to be blocked
+	for i := 0; i < maxConcurrent; i++ {
+		<-enteredChan
+	}
+
+	// Next request should be rate limited (429) immediately
+	tester.AssertGetResponse("http://localhost:8080", 429, "")
+
+	// Release one request
+	blockChan <- struct{}{}
+
+	// Wait for the released request to finish and for the limiter to be updated
+	<-reqDone
+
+	// Now we should be able to make one more request that blocks
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer func() { reqDone <- struct{}{} }()
+		resp, err := http.Get("http://localhost:8080")
+		if err != nil {
+			t.Errorf("request failed: %v", err)
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != 200 {
+			t.Errorf("expected status 200, got %d", resp.StatusCode)
+		}
+	}()
+
+	// Wait until it blocks
+	<-enteredChan
+
+	// Still at limit
+	tester.AssertGetResponse("http://localhost:8080", 429, "")
+
+	// Release all (2 more)
+	blockChan <- struct{}{}
+	blockChan <- struct{}{}
+	wg.Wait()
+
+	// Now it should be free
+	go func() { blockChan <- struct{}{} }()
+	resp, err := http.Get("http://localhost:8080")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	<-enteredChan // Consume the leftover signal
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestConcurrencyLimitMultipleKeys(t *testing.T) {
+	// Clear any leftover state
+	for len(enteredChan) > 0 {
+		<-enteredChan
+	}
+
+	maxConcurrent := 1
+	config := fmt.Sprintf(`{
+	"admin": {"listen": "localhost:2999"},
+	"apps": {
+		"http": {
+			"servers": {
+				"demo": {
+					"listen": [":8080"],
+					"routes": [{
+						"handle": [
+							{
+								"handler": "rate_limit",
+								"rate_limits": {
+									"concurrency_zone": {
+										"key": "{http.request.orig_uri.path}",
+										"max_concurrent": %d
+									}
+								}
+							},
+							{
+								"handler": "test_block"
+							}
+						]
+					}]
+				}
+			}
+		}
+	}
+}`, maxConcurrent)
+
+	tester := caddytest.NewTester(t)
+	tester.InitServer(config, "json")
+
+	var wg sync.WaitGroup
+	// Start request for path1
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		resp, err := http.Get("http://localhost:8080/path1")
+		if err != nil {
+			t.Errorf("request failed: %v", err)
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != 200 {
+			t.Errorf("expected status 200, got %d", resp.StatusCode)
+		}
+	}()
+
+	// Wait for request to be blocked
+	<-enteredChan
+
+	// path1 should be limited
+	tester.AssertGetResponse("http://localhost:8080/path1", 429, "")
+
+	// path2 should NOT be limited
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		resp, err := http.Get("http://localhost:8080/path2")
+		if err != nil {
+			t.Errorf("request failed: %v", err)
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != 200 {
+			t.Errorf("expected status 200, got %d", resp.StatusCode)
+		}
+	}()
+
+	// Wait for request to be blocked
+	<-enteredChan
+
+	// path2 should now be limited
+	tester.AssertGetResponse("http://localhost:8080/path2", 429, "")
+
+	// Release all
+	blockChan <- struct{}{}
+	blockChan <- struct{}{}
+	wg.Wait()
+}
+
+func TestMixedZones(t *testing.T) {
+	// Clear any leftover state
+	for len(enteredChan) > 0 {
+		<-enteredChan
+	}
+
+	config := `{
+	"admin": {"listen": "localhost:2999"},
+	"apps": {
+		"http": {
+			"servers": {
+				"mixed": {
+					"listen": [":8080"],
+					"routes": [{
+						"handle": [
+							{
+								"handler": "rate_limit",
+								"rate_limits": {
+									"window_zone": {
+										"key": "static",
+										"window": "10s",
+										"max_events": 1
+									},
+									"concurrency_zone": {
+										"key": "static",
+										"max_concurrent": 1
+									}
+								}
+							},
+							{
+								"handler": "test_block"
+							}
+						]
+					}]
+				}
+			}
+		}
+	}
+}`
+
+	tester := caddytest.NewTester(t)
+	tester.InitServer(config, "json")
+
+	// First request should pass both and block
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		resp, err := http.Get("http://localhost:8080")
+		if err != nil {
+			t.Errorf("request failed: %v", err)
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != 200 {
+			t.Errorf("expected status 200, got %d", resp.StatusCode)
+		}
+	}()
+
+	// Wait for request to be blocked
+	<-enteredChan
+
+	// Second request should be rate limited
+	tester.AssertGetResponse("http://localhost:8080", 429, "")
+
+	// Release first request
+	blockChan <- struct{}{}
+	wg.Wait()
+
+	// Now concurrency is free, but window zone is still limited (10s window)
+	tester.AssertGetResponse("http://localhost:8080", 429, "")
+}
+
+func TestConcurrencyRollback(t *testing.T) {
+	// Clear any leftover state
+	for len(enteredChan) > 0 {
+		<-enteredChan
+	}
+
+	config := `{
+	"admin": {"listen": "localhost:2999"},
+	"apps": {
+		"http": {
+			"servers": {
+				"rollback": {
+					"listen": [":8080"],
+					"routes": [{
+						"handle": [
+							{
+								"handler": "rate_limit",
+								"rate_limits": {
+									"concurrency_zone": {
+										"key": "static",
+										"max_concurrent": 1
+									},
+									"fail_zone": {
+										"key": "static",
+										"window": "1m",
+										"max_events": 1
+									}
+								}
+							},
+							{
+								"handler": "static_response",
+								"body": "success"
+							}
+						]
+					}]
+				}
+			}
+		}
+	}
+}`
+
+	tester := caddytest.NewTester(t)
+	tester.InitServer(config, "json")
+
+	// 1st request consumes the single event in fail_zone.
+	// Since static_response doesn't block, concurrency is immediately released.
+	tester.AssertGetResponse("http://localhost:8080", 200, "success")
+
+	// 2nd request passes concurrency_zone (count becomes 1)
+	// but fails fail_zone (max_events 1 is already consumed).
+	// It returns 429 and the concurrency_zone count should rollback to 0.
+	resp2, err := http.Get("http://localhost:8080")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != 429 {
+		t.Errorf("expected 429, got %d", resp2.StatusCode)
+	}
+	// A request blocked by a window_zone will have a Retry-After header.
+	if resp2.Header.Get("Retry-After") == "" {
+		t.Errorf("expected Retry-After header from fail_zone")
+	}
+
+	// 3rd request: If rollback succeeded, it will again pass concurrency_zone
+	// and fail at fail_zone, returning a 429 WITH a Retry-After header.
+	// If rollback failed, it will be rejected by concurrency_zone, returning
+	// a 429 WITHOUT a Retry-After header (since wait time is 0 for concurrency).
+	resp3, err := http.Get("http://localhost:8080")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp3.Body.Close()
+	if resp3.StatusCode != 429 {
+		t.Errorf("expected 429, got %d", resp3.StatusCode)
+	}
+	if resp3.Header.Get("Retry-After") == "" {
+		t.Errorf("concurrency rollback failed: request was rejected by concurrency_zone (missing Retry-After header)")
+	}
+}
+
+func TestConfigReloadPanic(t *testing.T) {
+	// First provision a window zone
+	rl1 := &RateLimit{
+		Window:    caddy.Duration(time.Second),
+		MaxEvents: 10,
+	}
+	rl1.limitersMap = newRateLimiterMap()
+	rl1.provision(caddy.Context{}, "panic_zone")
+
+	// Simulate a request to populate the map
+	rl1.limitersMap.getOrInsert("mykey", rl1)
+
+	// Now provision the same zone name as a concurrency zone (simulating config reload)
+	rl2 := &RateLimit{
+		MaxConcurrent: 5,
+	}
+	rl2.limitersMap = newRateLimiterMap()
+	rl2.provision(caddy.Context{}, "panic_zone")
+
+	// This should not panic if correctly handled
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Panicked! %v", r)
+		}
+	}()
+
+	// Simulate a request with the new config
+	limiter := rl2.limitersMap.getOrInsert("mykey", rl2)
+	_ = limiter.(*concurrencyLimiter) // This will panic because it's a ringBufferRateLimiter
+}

--- a/handler.go
+++ b/handler.go
@@ -139,6 +139,9 @@ func (h *Handler) Provision(ctx caddy.Context) error {
 
 	// provision each rate limit and put them in a slice so we can sort them
 	for name, rl := range h.RateLimits {
+		if h.Distributed != nil && rl.MaxConcurrent > 0 {
+			h.logger.Warn("distributed rate limiting is not supported for concurrency limits; skipping distributed syncing for this zone", zap.String("zone", name))
+		}
 		rl.zoneName = name
 		err := rl.provision(ctx, name)
 		if err != nil {
@@ -170,6 +173,13 @@ func (h *Handler) Provision(ctx caddy.Context) error {
 func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
 	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
 
+	var toRelease []*concurrencyLimiter
+	defer func() {
+		for _, cl := range toRelease {
+			cl.Release()
+		}
+	}()
+
 	// iterate the slice, not the map, so the order is deterministic
 	for _, rl := range h.rateLimits {
 		// ignore rate limit if request doesn't qualify
@@ -179,18 +189,27 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhtt
 
 		// make key for the individual rate limiter in this zone
 		key := repl.ReplaceAll(rl.Key, "")
-		limiter := rl.limitersMap.getOrInsert(key, rl.MaxEvents, time.Duration(rl.Window))
+		limiter := rl.limitersMap.getOrInsert(key, rl)
 
-		if h.Distributed == nil {
-			// internal rate limiter only
-			if dur := limiter.When(); dur > 0 {
-				return h.rateLimitExceeded(w, r, repl, rl.zoneName, key, dur)
+		switch l := limiter.(type) {
+		case *ringBufferRateLimiter:
+			if h.Distributed == nil {
+				// internal rate limiter only
+				if dur := l.When(); dur > 0 {
+					return h.rateLimitExceeded(w, r, repl, rl.zoneName, key, dur)
+				}
+			} else {
+				// distributed rate limiting; add last known state of other instances
+				if err := h.distributedRateLimiting(w, r, repl, l, key, rl.zoneName); err != nil {
+					return err
+				}
 			}
-		} else {
-			// distributed rate limiting; add last known state of other instances
-			if err := h.distributedRateLimiting(w, r, repl, limiter, key, rl.zoneName); err != nil {
-				return err
+
+		case *concurrencyLimiter:
+			if !l.Acquire() {
+				return h.rateLimitExceeded(w, r, repl, rl.zoneName, key, 0)
 			}
+			toRelease = append(toRelease, l)
 		}
 	}
 
@@ -199,13 +218,15 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhtt
 
 func (h *Handler) rateLimitExceeded(w http.ResponseWriter, r *http.Request, repl *caddy.Replacer, zoneName string, key string, wait time.Duration) error {
 	// add jitter, if configured
-	if h.random != nil {
+	if h.random != nil && wait > 0 {
 		jitter := h.randomFloatInRange(0, float64(wait)*h.Jitter)
 		wait += time.Duration(jitter)
 	}
 
-	// add 0.5 to ceil() instead of round() which FormatFloat() does automatically
-	w.Header().Set("Retry-After", strconv.FormatFloat(wait.Seconds()+0.5, 'f', 0, 64))
+	if wait > 0 {
+		// add 0.5 to ceil() instead of round() which FormatFloat() does automatically
+		w.Header().Set("Retry-After", strconv.FormatFloat(wait.Seconds()+0.5, 'f', 0, 64))
+	}
 
 	// emit log about exceeding rate limit (see #37)
 	remoteIP, _, err := net.SplitHostPort(r.RemoteAddr)

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -23,6 +23,10 @@ import (
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 )
 
+// idleLimiterTTL defines how long a concurrency limiter can remain in memory
+// with 0 active requests before it is garbage collected by the sweep() routine.
+const idleLimiterTTL = 5 * time.Minute
+
 // RateLimit describes an HTTP rate limit zone.
 type RateLimit struct {
 	// Request matchers, which defines the class of requests that are in the RL zone.
@@ -42,6 +46,9 @@ type RateLimit struct {
 	// Duration of the sliding window.
 	Window caddy.Duration `json:"window,omitempty"`
 
+	// Maximum number of concurrent requests allowed.
+	MaxConcurrent int `json:"max_concurrent,omitempty"`
+
 	matcherSets caddyhttp.MatcherSets
 
 	zoneName string
@@ -50,10 +57,13 @@ type RateLimit struct {
 }
 
 func (rl *RateLimit) provision(ctx caddy.Context, name string) error {
-	if rl.Window <= 0 {
+	if rl.MaxConcurrent > 0 && (rl.MaxEvents > 0 || rl.Window > 0) {
+		return fmt.Errorf("cannot use both max_concurrent and window/max_events")
+	}
+	if rl.MaxConcurrent == 0 && rl.Window <= 0 {
 		return fmt.Errorf("window must be greater than zero")
 	}
-	if rl.MaxEvents < 0 {
+	if rl.MaxConcurrent == 0 && rl.MaxEvents < 0 {
 		return fmt.Errorf("max_events must be at least zero")
 	}
 
@@ -73,49 +83,91 @@ func (rl *RateLimit) provision(ctx caddy.Context, name string) error {
 	if val, loaded := rateLimits.LoadOrStore(name, rl.limitersMap); loaded {
 		rl.limitersMap = val.(*rateLimitersMap)
 	}
-	rl.limitersMap.updateAll(rl.MaxEvents, time.Duration(rl.Window))
+	rl.limitersMap.updateAll(rl)
 
 	return nil
 }
 
 func (rl *RateLimit) permissiveness() float64 {
+	if rl.MaxConcurrent > 0 {
+		// To make concurrency limits comparable to rate limits for sorting,
+		// we treat MaxConcurrent as a rate of events per second.
+		return float64(rl.MaxConcurrent) / float64(time.Second)
+	}
 	return float64(rl.MaxEvents) / float64(rl.Window)
 }
 
+// RateLimiter is a marker interface for rate limiters.
+// It will exclusively be either *ringBufferRateLimiter or *concurrencyLimiter.
+type RateLimiter interface {
+	isRateLimiter()
+}
+
 type rateLimitersMap struct {
-	limiters   map[string]*ringBufferRateLimiter
+	limiters   map[string]RateLimiter
 	limitersMu sync.Mutex
 }
 
 func newRateLimiterMap() *rateLimitersMap {
 	var rlm rateLimitersMap
-	rlm.limiters = make(map[string]*ringBufferRateLimiter)
+	rlm.limiters = make(map[string]RateLimiter)
 	return &rlm
 }
 
 // getOrInsert returns an existing rate limiter from the map, or inserts a new
 // one with the desired settings and returns it.
-func (rlm *rateLimitersMap) getOrInsert(key string, maxEvents int, window time.Duration) *ringBufferRateLimiter {
+func (rlm *rateLimitersMap) getOrInsert(key string, rl *RateLimit) RateLimiter {
 	rlm.limitersMu.Lock()
 	defer rlm.limitersMu.Unlock()
 
 	rateLimiter, ok := rlm.limiters[key]
-	if !ok {
-		newRateLimiter := newRingBufferRateLimiter(maxEvents, window)
-		rlm.limiters[key] = newRateLimiter
-		return newRateLimiter
+	if ok {
+		// Verify the existing limiter matches the current config type
+		switch l := rateLimiter.(type) {
+		case *concurrencyLimiter:
+			if rl.MaxConcurrent > 0 {
+				// Prevent sweep() from deleting this while we are between getOrInsert and Acquire
+				l.lastAccess.Store(now().UnixNano())
+				return rateLimiter
+			}
+		case *ringBufferRateLimiter:
+			if rl.MaxConcurrent == 0 {
+				return rateLimiter
+			}
+		}
+		// Type mismatch (likely due to config reload). We fall through to recreate it.
 	}
+
+	if rl.MaxConcurrent > 0 {
+		rateLimiter = newConcurrencyLimiter(int64(rl.MaxConcurrent))
+	} else {
+		rateLimiter = newRingBufferRateLimiter(rl.MaxEvents, time.Duration(rl.Window))
+	}
+	rlm.limiters[key] = rateLimiter
 	return rateLimiter
 }
 
 // updateAll updates existing rate limiters with new settings.
-func (rlm *rateLimitersMap) updateAll(maxEvents int, window time.Duration) {
+func (rlm *rateLimitersMap) updateAll(rl *RateLimit) {
 	rlm.limitersMu.Lock()
 	defer rlm.limitersMu.Unlock()
 
-	for _, limiter := range rlm.limiters {
-		limiter.SetMaxEvents(maxEvents)
-		limiter.SetWindow(time.Duration(window))
+	for key, limiter := range rlm.limiters {
+		switch l := limiter.(type) {
+		case *concurrencyLimiter:
+			if rl.MaxConcurrent > 0 {
+				l.limit.Store(int64(rl.MaxConcurrent))
+			} else {
+				delete(rlm.limiters, key)
+			}
+		case *ringBufferRateLimiter:
+			if rl.MaxConcurrent == 0 {
+				l.SetMaxEvents(rl.MaxEvents)
+				l.SetWindow(time.Duration(rl.Window))
+			} else {
+				delete(rlm.limiters, key)
+			}
+		}
 	}
 }
 
@@ -124,31 +176,43 @@ func (rlm *rateLimitersMap) sweep() {
 	rlm.limitersMu.Lock()
 	defer rlm.limitersMu.Unlock()
 
-	for key, rl := range rlm.limiters {
-		func(rl *ringBufferRateLimiter) {
-			rl.mu.Lock()
-			defer rl.mu.Unlock()
+	for key, limiter := range rlm.limiters {
+		switch l := limiter.(type) {
+		case *ringBufferRateLimiter:
+			func(rl *ringBufferRateLimiter) {
+				rl.mu.Lock()
+				defer rl.mu.Unlock()
 
-			// no point in keeping a ring buffer of size 0 around
-			if len(rl.ring) == 0 {
-				delete(rlm.limiters, key)
-				return
-			}
+				// no point in keeping a ring buffer of size 0 around
+				if len(rl.ring) == 0 {
+					delete(rlm.limiters, key)
+					return
+				}
 
-			// get newest event in ring (should come right before oldest)
-			cursorNewest := rl.cursor - 1
-			if cursorNewest < 0 {
-				cursorNewest = len(rl.ring) - 1
-			}
-			newest := rl.ring[cursorNewest]
-			window := rl.window
+				// get newest event in ring (should come right before oldest)
+				cursorNewest := rl.cursor - 1
+				if cursorNewest < 0 {
+					cursorNewest = len(rl.ring) - 1
+				}
+				newest := rl.ring[cursorNewest]
+				window := rl.window
 
-			// if newest event in memory is outside the window,
-			// the entire ring has expired and can be forgotten
-			if newest.Add(window).Before(now()) {
-				delete(rlm.limiters, key)
+				// if newest event in memory is outside the window,
+				// the entire ring has expired and can be forgotten
+				if newest.Add(window).Before(now()) {
+					delete(rlm.limiters, key)
+				}
+			}(l)
+		case *concurrencyLimiter:
+			// for concurrency limiters, we can remove them if they are idle
+			// and have no active requests.
+			if l.current.Load() == 0 {
+				lastAccess := time.Unix(0, l.lastAccess.Load())
+				if now().Sub(lastAccess) > idleLimiterTTL {
+					delete(rlm.limiters, key)
+				}
 			}
-		}(rl)
+		}
 	}
 }
 
@@ -158,11 +222,18 @@ func (rlm *rateLimitersMap) rlStateForZone(timestamp time.Time) map[string]rlSta
 
 	rlm.limitersMu.Lock()
 	defer rlm.limitersMu.Unlock()
-	for key, rl := range rlm.limiters {
-		count, oldestEvent := rl.Count(timestamp)
-		state[key] = rlStateValue{
-			Count:       count,
-			OldestEvent: oldestEvent,
+	for key, limiter := range rlm.limiters {
+		switch l := limiter.(type) {
+		case *ringBufferRateLimiter:
+			count, oldestEvent := l.Count(timestamp)
+			state[key] = rlStateValue{
+				Count:       count,
+				OldestEvent: oldestEvent,
+			}
+		case *concurrencyLimiter:
+			state[key] = rlStateValue{
+				Count: int(l.current.Load()),
+			}
 		}
 	}
 

--- a/ringbuffer.go
+++ b/ringbuffer.go
@@ -30,6 +30,8 @@ type ringBufferRateLimiter struct {
 	cursor int         // always points to the oldest timestamp
 }
 
+func (*ringBufferRateLimiter) isRateLimiter() {}
+
 // newRingBufferRateLimiter sets up a new rate limiter, allowing maxEvents
 // in a sliding window of size window. If maxEvents is 0, no events are
 // allowed. If window is 0, all events are allowed. It panics if maxEvents or


### PR DESCRIPTION
Features
   * Concurrency Limiting: Added a new `max_concurrent` configuration option to limit in-flight requests per key.
   * Mutually Exclusive Zones: A rate limit zone must define either window/events or max_concurrent, but not both.

Design Decisions & Architecture
   * Atomic Counters (`concurrencyLimiter`): Implemented using fast, lock-free atomic.Int64 counters
   * Deferred Rollback (toRelease): When a request matches multiple zones and passes a concurrency zone but gets rejected by a subsequent windowed zone, a defer block ensures the concurrency limit is released.
   * Garbage Collection (Sweep): Concurrency limiters track their lastAccess time. The background sweep() goroutine safely cleans them up if they are idle for a minute and have 0 active requests.
   * Config Reload: The getOrInsert method now explicitly checks the RateLimiter underlying type. If user hot-reloads Caddy to change a zone from a window limit to a concurrency limit, it cleanly recreates the limiter.
   * Permissiveness Sorting Optimization: max_concurrent is mathematically mapped to an equivalent “events per second” rate. This allows the handler to evaluate the strictest limiters first, saving CPU cycles on requests that are set to fail anyway.

Disclosure: PR assisted by AI (Gemini), signed-off by me. 