### PR TITLE
fix: re-register rate limit metrics on config reload (closes #100)

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -1,7 +1,10 @@
 package caddyrl
 
 import (
+	"errors"
+	"fmt"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -16,16 +19,44 @@ type rateLimitMetrics struct {
 	config        *prometheus.CounterVec
 }
 
-// globalMetrics is a package-level singleton that holds the registered Prometheus
-// collectors. It must be a singleton because Prometheus does not allow the same
-// collector to be registered twice in a registry. During Caddy config reloads
-// each Handler is re-provisioned, but the metrics registry persists, so
-// registerMetrics only sets this on the first successful registration and all
-// subsequent Handler instances share the same collectors via this reference.
-var globalMetrics *rateLimitMetrics
+// globalMetrics holds the currently-active rate limit collectors.
+//
+// It is stored atomically because Caddy provisions a brand-new metrics registry
+// on every config reload (caddy.Context.GetMetricsRegistry returns a fresh
+// prometheus registry per context) and rebinds the admin /metrics endpoint to
+// it, while the previous config's in-flight request goroutines may still be
+// reading these collectors. A plain pointer set only once would both data-race
+// against those readers and keep pointing at collectors registered with the old,
+// orphaned registry — so /metrics, which serves the new registry, would report
+// no rate-limit activity after any reload. See issue #100.
+var globalMetrics atomic.Pointer[rateLimitMetrics]
 
-// initializeMetrics creates and registers all rate limit metrics with Caddy's internal registry
-func initializeMetrics(registry prometheus.Registerer) (*rateLimitMetrics, error) {
+// register registers c with reg, returning the already-registered collector of
+// the same definition when one exists. Caddy hands every rate_limit handler the
+// same registry within a single config (so sibling handlers register identical
+// collectors) and a fresh registry on each reload; Prometheus reports an existing
+// collector as an AlreadyRegisteredError carrying the ExistingCollector. Reusing
+// it ensures every handler — and the served /metrics endpoint — increments one
+// shared collector instead of an orphaned duplicate. See issue #100.
+func register[T prometheus.Collector](reg prometheus.Registerer, c T) (T, error) {
+	if err := reg.Register(c); err != nil {
+		var already prometheus.AlreadyRegisteredError
+		if errors.As(err, &already) {
+			if existing, ok := already.ExistingCollector.(T); ok {
+				return existing, nil
+			}
+			return c, fmt.Errorf("already-registered rate limit metric has unexpected type %T", already.ExistingCollector)
+		}
+		return c, err
+	}
+	return c, nil
+}
+
+// initializeMetrics creates the rate limit collectors and registers them with the
+// provided registry, reconciling against any collectors already registered (by a
+// sibling handler sharing the registry). The returned struct always references the
+// collectors that are actually registered with reg.
+func initializeMetrics(reg prometheus.Registerer) (*rateLimitMetrics, error) {
 	const ns, sub = "caddy", "rate_limit"
 
 	metrics := &rateLimitMetrics{
@@ -86,43 +117,35 @@ func initializeMetrics(registry prometheus.Registerer) (*rateLimitMetrics, error
 		),
 	}
 
-	// Register each metric and check for AlreadyRegisteredError
-	collectors := []prometheus.Collector{
-		metrics.declinedTotal,
-		metrics.requestsTotal,
-		metrics.processTime,
-		metrics.keysTotal,
-		metrics.config,
+	var err error
+	if metrics.declinedTotal, err = register(reg, metrics.declinedTotal); err != nil {
+		return nil, err
 	}
-
-	for _, collector := range collectors {
-		if err := registry.Register(collector); err != nil {
-			// Check if it's already registered error, which is expected on config reload
-			if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
-				// If it's not an AlreadyRegisteredError, return the actual error
-				return nil, err
-			}
-			// If it's AlreadyRegisteredError, continue - this is expected
-		}
+	if metrics.requestsTotal, err = register(reg, metrics.requestsTotal); err != nil {
+		return nil, err
 	}
-
+	if metrics.processTime, err = register(reg, metrics.processTime); err != nil {
+		return nil, err
+	}
+	if metrics.keysTotal, err = register(reg, metrics.keysTotal); err != nil {
+		return nil, err
+	}
+	if metrics.config, err = register(reg, metrics.config); err != nil {
+		return nil, err
+	}
 	return metrics, nil
 }
 
-// registerMetrics registers all rate limit metrics with the provided Prometheus registry
+// registerMetrics builds the rate limit collectors against reg — which Caddy
+// replaces with a fresh registry on every config reload — and atomically
+// publishes them so the record* methods (and thus the /metrics endpoint) observe
+// the collectors registered with the currently-served registry. See issue #100.
 func registerMetrics(reg prometheus.Registerer) error {
-	// Try to initialize metrics - may handle AlreadyRegisteredError gracefully
 	metrics, err := initializeMetrics(reg)
 	if err != nil {
 		return err
 	}
-
-	// Set the global metrics instance if it's nil
-	// On config reload, this ensures we continue using metrics even if some were already registered
-	if globalMetrics == nil {
-		globalMetrics = metrics
-	}
-
+	globalMetrics.Store(metrics)
 	return nil
 }
 
@@ -138,7 +161,8 @@ func newMetricsCollector() *metricsCollector {
 
 // recordRequest records a request that passed through the rate limit module
 func (mc *metricsCollector) recordRequest(hasZone bool) {
-	if !mc.enabled || globalMetrics == nil {
+	m := globalMetrics.Load()
+	if !mc.enabled || m == nil {
 		return
 	}
 
@@ -147,34 +171,37 @@ func (mc *metricsCollector) recordRequest(hasZone bool) {
 		hasZoneStr = "true"
 	}
 	// Record zone-level aggregate metric (key is empty for zone-level aggregation)
-	globalMetrics.requestsTotal.WithLabelValues(hasZoneStr, "").Inc()
+	m.requestsTotal.WithLabelValues(hasZoneStr, "").Inc()
 }
 
 // recordRequestPerKey records a request for a specific zone and key
 func (mc *metricsCollector) recordRequestPerKey(zone, key string) {
-	if !mc.enabled || globalMetrics == nil {
+	m := globalMetrics.Load()
+	if !mc.enabled || m == nil {
 		return
 	}
 
 	// Record both zone-level aggregate and per-key detailed metrics
-	globalMetrics.requestsTotal.WithLabelValues(zone, "").Inc()  // Zone-level aggregate
-	globalMetrics.requestsTotal.WithLabelValues(zone, key).Inc() // Per-key detailed
+	m.requestsTotal.WithLabelValues(zone, "").Inc()  // Zone-level aggregate
+	m.requestsTotal.WithLabelValues(zone, key).Inc() // Per-key detailed
 }
 
 // recordDeclinedRequest records a request that was declined due to rate limiting
 func (mc *metricsCollector) recordDeclinedRequest(zone, key string) {
-	if !mc.enabled || globalMetrics == nil {
+	m := globalMetrics.Load()
+	if !mc.enabled || m == nil {
 		return
 	}
 
 	// Record both zone-level aggregate and per-key detailed metrics
-	globalMetrics.declinedTotal.WithLabelValues(zone, "").Inc()  // Zone-level aggregate
-	globalMetrics.declinedTotal.WithLabelValues(zone, key).Inc() // Per-key detailed
+	m.declinedTotal.WithLabelValues(zone, "").Inc()  // Zone-level aggregate
+	m.declinedTotal.WithLabelValues(zone, key).Inc() // Per-key detailed
 }
 
 // recordProcessTime records the time taken to process rate limiting
 func (mc *metricsCollector) recordProcessTime(duration time.Duration, hasZone bool) {
-	if !mc.enabled || globalMetrics == nil {
+	m := globalMetrics.Load()
+	if !mc.enabled || m == nil {
 		return
 	}
 
@@ -183,36 +210,39 @@ func (mc *metricsCollector) recordProcessTime(duration time.Duration, hasZone bo
 		hasZoneStr = "true"
 	}
 	// Record zone-level aggregate metric (key is empty for zone-level aggregation)
-	globalMetrics.processTime.WithLabelValues(hasZoneStr, "").Observe(duration.Seconds())
+	m.processTime.WithLabelValues(hasZoneStr, "").Observe(duration.Seconds())
 }
 
 // recordProcessTimePerKey records the time taken to process rate limiting for a specific zone and key
 func (mc *metricsCollector) recordProcessTimePerKey(duration time.Duration, zone, key string) {
-	if !mc.enabled || globalMetrics == nil {
+	m := globalMetrics.Load()
+	if !mc.enabled || m == nil {
 		return
 	}
 
 	// Record both zone-level aggregate and per-key detailed metrics
-	globalMetrics.processTime.WithLabelValues(zone, "").Observe(duration.Seconds())  // Zone-level aggregate
-	globalMetrics.processTime.WithLabelValues(zone, key).Observe(duration.Seconds()) // Per-key detailed
+	m.processTime.WithLabelValues(zone, "").Observe(duration.Seconds())  // Zone-level aggregate
+	m.processTime.WithLabelValues(zone, key).Observe(duration.Seconds()) // Per-key detailed
 }
 
 // updateKeysCount updates the count of keys for a specific zone
 func (mc *metricsCollector) updateKeysCount(zone string, count int) {
-	if !mc.enabled || globalMetrics == nil {
+	m := globalMetrics.Load()
+	if !mc.enabled || m == nil {
 		return
 	}
 
-	globalMetrics.keysTotal.WithLabelValues(zone).Set(float64(count))
+	m.keysTotal.WithLabelValues(zone).Set(float64(count))
 }
 
 // recordConfig records the configuration of a rate limit zone (called once during provision)
 func (mc *metricsCollector) recordConfig(zone string, maxEvents int, window time.Duration, ipv4Prefix, ipv6Prefix int) {
-	if !mc.enabled || globalMetrics == nil {
+	m := globalMetrics.Load()
+	if !mc.enabled || m == nil {
 		return
 	}
 
-	globalMetrics.config.WithLabelValues(zone,
+	m.config.WithLabelValues(zone,
 		strconv.Itoa(maxEvents),
 		window.String(),
 		strconv.Itoa(ipv4Prefix),

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -3,7 +3,9 @@ package caddyrl
 import (
 	"fmt"
 	"strconv"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/caddyserver/caddy/v2/caddytest"
 	"github.com/prometheus/client_golang/prometheus"
@@ -15,7 +17,7 @@ func TestMetrics(t *testing.T) {
 	prometheus.DefaultRegisterer = prometheus.NewRegistry()
 
 	// Reset global metrics
-	globalMetrics = nil
+	globalMetrics.Store(nil)
 
 	window := 10
 	maxEvents := 2
@@ -60,12 +62,13 @@ func TestMetrics(t *testing.T) {
 	tester.InitServer(config, "json")
 
 	// Ensure metrics are initialized
-	if globalMetrics == nil {
+	m := globalMetrics.Load()
+	if m == nil {
 		t.Fatal("Expected globalMetrics to be initialized")
 	}
 
 	// Test that configuration metrics are recorded
-	configMetric := testutil.ToFloat64(globalMetrics.config.WithLabelValues("test_zone", strconv.Itoa(maxEvents), fmt.Sprintf("%ds", window), "0", "0"))
+	configMetric := testutil.ToFloat64(m.config.WithLabelValues("test_zone", strconv.Itoa(maxEvents), fmt.Sprintf("%ds", window), "0", "0"))
 	if configMetric == 0 {
 		t.Error("Expected configuration metric to be recorded")
 	}
@@ -76,8 +79,8 @@ func TestMetrics(t *testing.T) {
 	}
 
 	// Check request metrics - verify both zone-level and per-key metrics
-	zoneLevelRequestsMetric := testutil.ToFloat64(globalMetrics.requestsTotal.WithLabelValues("test_zone", ""))
-	perKeyRequestsMetric := testutil.ToFloat64(globalMetrics.requestsTotal.WithLabelValues("test_zone", "static"))
+	zoneLevelRequestsMetric := testutil.ToFloat64(m.requestsTotal.WithLabelValues("test_zone", ""))
+	perKeyRequestsMetric := testutil.ToFloat64(m.requestsTotal.WithLabelValues("test_zone", "static"))
 
 	if zoneLevelRequestsMetric < float64(maxEvents) {
 		t.Errorf("Expected at least %d zone-level requests metric, got %f", maxEvents, zoneLevelRequestsMetric)
@@ -90,8 +93,8 @@ func TestMetrics(t *testing.T) {
 	tester.AssertGetResponse("http://localhost:8080", 429, "")
 
 	// Check declined requests metrics - verify both zone-level and per-key metrics
-	zoneLevelDeclinedMetric := testutil.ToFloat64(globalMetrics.declinedTotal.WithLabelValues("test_zone", ""))
-	perKeyDeclinedMetric := testutil.ToFloat64(globalMetrics.declinedTotal.WithLabelValues("test_zone", "static"))
+	zoneLevelDeclinedMetric := testutil.ToFloat64(m.declinedTotal.WithLabelValues("test_zone", ""))
+	perKeyDeclinedMetric := testutil.ToFloat64(m.declinedTotal.WithLabelValues("test_zone", "static"))
 
 	if zoneLevelDeclinedMetric == 0 {
 		t.Error("Expected zone-level declined requests metric to be recorded")
@@ -101,8 +104,8 @@ func TestMetrics(t *testing.T) {
 	}
 
 	// Check process time histograms - verify both zone-level and per-key metrics
-	zoneLevelProcessTimeHistogram := globalMetrics.processTime.WithLabelValues("test_zone", "")
-	perKeyProcessTimeHistogram := globalMetrics.processTime.WithLabelValues("test_zone", "static")
+	zoneLevelProcessTimeHistogram := m.processTime.WithLabelValues("test_zone", "")
+	perKeyProcessTimeHistogram := m.processTime.WithLabelValues("test_zone", "static")
 
 	if zoneLevelProcessTimeHistogram == nil {
 		t.Error("Expected zone-level process time histogram to be created")
@@ -110,4 +113,97 @@ func TestMetrics(t *testing.T) {
 	if perKeyProcessTimeHistogram == nil {
 		t.Error("Expected per-key process time histogram to be created")
 	}
+}
+
+// TestMetricsReRegisterOnReload is a regression test for issue #100: on a Caddy
+// config reload the handler is re-provisioned with a brand-new metrics registry
+// (caddy.Context.GetMetricsRegistry returns a fresh prometheus registry per
+// context). The rate limit collectors must be re-registered against that new
+// registry and globalMetrics re-pointed at them, otherwise increments land in
+// the old, orphaned registry while /metrics serves the new one — making
+// caddy_rate_limit_* metrics appear stuck/absent after any reload.
+func TestMetricsReRegisterOnReload(t *testing.T) {
+	globalMetrics.Store(nil)
+
+	// First config load: register against the first per-context registry.
+	reg1 := prometheus.NewPedanticRegistry()
+	if err := registerMetrics(reg1); err != nil {
+		t.Fatalf("initial registration: %v", err)
+	}
+
+	mc := newMetricsCollector()
+	mc.recordDeclinedRequest("zoneA", "k1") // recorded into reg1's collectors
+
+	// Caddy reload: a brand-new registry replaces reg1 and is what /metrics now
+	// serves. The same handler code path runs registerMetrics again.
+	reg2 := prometheus.NewPedanticRegistry()
+	if err := registerMetrics(reg2); err != nil {
+		t.Fatalf("reload registration: %v", err)
+	}
+
+	// After the reload, increments must land in the registry that /metrics now
+	// serves (reg2), not the orphaned reg1.
+	mc.recordDeclinedRequest("zoneA", "k1")
+
+	// The post-reload registry must actually contain the rate limit series.
+	// Before the fix, reg2 had zero caddy_rate_limit_* samples after reload.
+	got, err := testutil.GatherAndCount(reg2, "caddy_rate_limit_declined_requests_total")
+	if err != nil {
+		t.Fatalf("gathering reg2: %v", err)
+	}
+	if got != 2 { // recordDeclinedRequest writes the zone aggregate + the per-key series
+		t.Fatalf("expected 2 declined series in the post-reload registry, got %d", got)
+	}
+
+	value := testutil.ToFloat64(globalMetrics.Load().declinedTotal.WithLabelValues("zoneA", "k1"))
+	if value != 1 {
+		t.Errorf("expected post-reload per-key declined counter = 1, got %v", value)
+	}
+}
+
+// TestMetricsConcurrentReloadNoRace exercises the data race the previous
+// singleton design had (issue #100): config reloads write globalMetrics from a
+// separate goroutine while in-flight requests read it on the hot path. Run with
+// `go test -race` to assert the atomic.Pointer makes that access safe.
+func TestMetricsConcurrentReloadNoRace(t *testing.T) {
+	globalMetrics.Store(nil)
+	if err := registerMetrics(prometheus.NewPedanticRegistry()); err != nil {
+		t.Fatalf("initial registration: %v", err)
+	}
+
+	mc := newMetricsCollector()
+
+	const readers = 8
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					mc.recordRequest(true)
+					mc.recordDeclinedRequest("zoneA", "k1")
+					mc.recordProcessTimePerKey(time.Millisecond, "zoneA", "k1")
+					mc.updateKeysCount("zoneA", 1)
+				}
+			}
+		}()
+	}
+
+	// Simulate repeated reloads (each with a fresh registry) concurrent with the
+	// in-flight requests above.
+	for i := 0; i < 100; i++ {
+		if err := registerMetrics(prometheus.NewPedanticRegistry()); err != nil {
+			t.Errorf("reload %d: %v", i, err)
+			break
+		}
+	}
+
+	close(stop)
+	wg.Wait()
 }


### PR DESCRIPTION
Fixes #100: `caddy_rate_limit_*` metrics stop updating after a config reload
(e.g. a ConfigMap remount after `helm upgrade`).

### What's going on

Caddy makes a fresh prometheus registry on every reload and points `/metrics`
at the new one. `registerMetrics` only set the `globalMetrics` singleton while
it was nil, so after a reload it kept pointing at the *old* registry's
collectors. Increments went there while `/metrics` served the new (empty) one —
so the series read 0.

### The fix

- Register collectors against the registry passed to each `Provision`, and store
  them in an `atomic.Pointer` so the active collectors always match the registry
  `/metrics` is serving.
- Keep the one useful thing the nil check did — avoiding double-registration when
  multiple `rate_limit` handlers share a registry — by reusing
  `AlreadyRegisteredError.ExistingCollector` instead of dropping the new
  collectors.
- The atomic pointer also closes the data race raised in the issue: `record*`
  reads the singleton from request goroutines while a reload writes it, and the
  new config is provisioned before the old one stops, so live requests overlap
  the write.

### Tests

- `TestMetricsReRegisterOnReload` — post-reload increments land in the new
  registry (fails on the old code).
- `TestMetricsConcurrentReloadNoRace` — concurrent reloads vs. request reads,
  clean under `go test -race`.

`go test -race ./...` passes.
